### PR TITLE
Added fix for missing CSS import that was breaking diff views

### DIFF
--- a/src/webui/app/views/request/show.html.erb
+++ b/src/webui/app/views/request/show.html.erb
@@ -4,6 +4,7 @@
 
 <% content_for :content_for_head do %>
   <%= stylesheet_link_tag 'jquery.autocomplete' %>
+  <%= stylesheet_link_tag 'cm2/suse' %>
 <% end %>
 <%= javascript_include_tag 'jquery.autocomplete.pack', 'jquery.expander.min' %>
 

--- a/src/webui/app/views/shared/_sourcediff.html.erb
+++ b/src/webui/app/views/shared/_sourcediff.html.erb
@@ -1,3 +1,8 @@
+<% content_for :content_for_head do %>
+  <%= stylesheet_link_tag 'jquery.autocomplete' %>
+  <%= stylesheet_link_tag 'cm2/suse' %>
+<% end %>
+
 <% content_for :head_javascript do %>
   function collapse_expand(file_id) {
     if ($('#diff_view_' + file_id + '_placeholder').length == 1) {
@@ -25,6 +30,8 @@
     }
   }
 <% end %>
+
+<%= javascript_include_tag 'jquery.autocomplete.pack', 'jquery.expander.min' %>
 
 <% editor_width ||= 'auto' %>
 <% css_class ||= nil %>


### PR DESCRIPTION
Diffs didn't have the proper CCS loaded so diffs were getting mangled on
opening and this change just adds that in.

[endlessm/eos-shell#6280]
